### PR TITLE
added comment about jdk/jre error

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A blockchain simulator for SE 575
 cd Simulator
 ./gradlew run
 ```
+(If both JRE and JDK are installed, gradle may use java from the JRE. Ensure JAVA_HOME is set to path of JDK.)
 
 # Frontend
 ## Installation


### PR DESCRIPTION
jdk and jre both being installed, gradle may use jre java path instead of jdk. fix is to make sure java_home is set to jdk path